### PR TITLE
Updated access and files after the November 2021 update

### DIFF
--- a/182739/unprocessed/7T/rfMRI_REST4_AP/182739_7T_rfMRI_REST4_AP.nii.gz
+++ b/182739/unprocessed/7T/rfMRI_REST4_AP/182739_7T_rfMRI_REST4_AP.nii.gz
@@ -1,0 +1,1 @@
+../../../../.git/annex/objects/Kv/kp/MD5E-s1408706105--b709640f2d14611dba9acdaeeca0bcd3.nii.gz/MD5E-s1408706105--b709640f2d14611dba9acdaeeca0bcd3.nii.gz

--- a/195041/unprocessed/3T/T1w_MPR1/195041_3T_T1w_MPR1.nii.gz
+++ b/195041/unprocessed/3T/T1w_MPR1/195041_3T_T1w_MPR1.nii.gz
@@ -1,0 +1,1 @@
+../../../../.git/annex/objects/v1/9W/MD5E-s32143859--f3753c3b7fb2aca42dfb42198ad402de.nii.gz/MD5E-s32143859--f3753c3b7fb2aca42dfb42198ad402de.nii.gz

--- a/200614/unprocessed/7T/tfMRI_MOVIE3_PA/200614_7T_tfMRI_MOVIE3_PA.nii.gz
+++ b/200614/unprocessed/7T/tfMRI_MOVIE3_PA/200614_7T_tfMRI_MOVIE3_PA.nii.gz
@@ -1,0 +1,1 @@
+../../../../.git/annex/objects/xZ/Wx/MD5E-s1415374984--0555f69c8164844ed5476d4f50b776ba.nii.gz/MD5E-s1415374984--0555f69c8164844ed5476d4f50b776ba.nii.gz

--- a/706040/unprocessed/7T/tfMRI_MOVIE3_PA/706040_7T_tfMRI_MOVIE3_PA.nii.gz
+++ b/706040/unprocessed/7T/tfMRI_MOVIE3_PA/706040_7T_tfMRI_MOVIE3_PA.nii.gz
@@ -1,0 +1,1 @@
+../../../../.git/annex/objects/Vm/87/MD5E-s1337127340--8418f6af2aeaf3ce0dae85dbfcb0d792.nii.gz/MD5E-s1337127340--8418f6af2aeaf3ce0dae85dbfcb0d792.nii.gz


### PR DESCRIPTION
After https://github.com/datalad-datasets/human-connectome-project-openaccess/pull/31 this PR updates this subset of the HCP dataset with four additional files and an updated submodule change. Availability updates are already pushed.